### PR TITLE
Update sb3_kaz_vector.py

### DIFF
--- a/tutorials/SB3/kaz/sb3_kaz_vector.py
+++ b/tutorials/SB3/kaz/sb3_kaz_vector.py
@@ -98,8 +98,8 @@ def eval(env_fn, num_games: int = 100, render_mode: str | None = None, **env_kwa
         for agent in env.agent_iter():
             obs, reward, termination, truncation, info = env.last()
 
-            for agent in env.agents:
-                rewards[agent] += env.rewards[agent]
+            for a in env.agents:
+                rewards[a] += env.rewards[agent]
 
             if termination or truncation:
                 break


### PR DESCRIPTION
Fixed a bug in agent iteration

# Description

In the tutorial of utilizing SB3 for the KAZ environment, the original author updates the reward Dict using the same variable name in an inner loop as that used for `env.agent_iter()`, which leads to the consequence that the actual decision-maker is always the last agent namely `knight_1`. I have just revised it to a different name and it works fine.

## Type of change

- Bug fix (non-breaking change which fixes an issue)



# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
